### PR TITLE
Fix PID fetch for VS Code forks like "VS Codium"

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -42,8 +42,11 @@ function activate(context) {
             return;
         }
 
+        // Retrieve the process name for the current VS Code instance (Solution for using forks of VS Code)
+        const process_name = process.title.substring(process.title.lastIndexOf('/') + 1);
+
         // Retrieving the process ids of VS code
-        const processIds = cp.execSync('pgrep \'code\' || pgrep \'codium\'').toString().split('\n');
+        const processIds = cp.execSync(`pgrep ${process_name}`).toString().split('\n');
         processIds.pop();
 
         // Retrieving all window ids

--- a/extension.js
+++ b/extension.js
@@ -43,7 +43,7 @@ function activate(context) {
         }
 
         // Retrieving the process ids of VS code
-        const processIds = cp.execSync('pgrep \'code\'').toString().split('\n');
+        const processIds = cp.execSync('pgrep \'code\' || pgrep \'codium\'').toString().split('\n');
         processIds.pop();
 
         // Retrieving all window ids


### PR DESCRIPTION
Hi,
I've noticed the extension didn't worked with VS Codium on Linux, a telemetry-free, MIT-licensed fork of VS Code. The problem is VS Codium labeled it's process "codium", not "code". This PR solve this by first retrieving the process title, which is then used to retrieve all running instances PID, no matter which flavor of VS Code the user is currently running.