### PR TITLE
Add support for sway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # GlassIt-VSC
 
-[![Version](https://vsmarketplacebadge.apphb.com/version/s-nlf-fh.glassit.svg)](https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit)
-[![Installs](https://vsmarketplacebadge.apphb.com/installs/s-nlf-fh.glassit.svg)](https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit)
-[![Ratings](https://vsmarketplacebadge.apphb.com/rating/s-nlf-fh.glassit.svg)](https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit)
-
 VS Code Extension to set window to transparent on Windows and Linux platforms.
 
 This extension is the VS Code version of [GlassIt](https://packagecontrol.io/packages/GlassIt) of Sublime Text plugin.

--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,8 @@ const { workspace, window, commands } = require('vscode');
 const shell = require('node-powershell');
 
 function activate(context) {
+
+    console.log('ctx', process.platform);
     if (process.platform == 'win32') {
         const path = context.asAbsolutePath('./SetTransparency.cs');
         const ps = new shell({
@@ -54,6 +56,7 @@ function activate(context) {
             `xprop -root | grep '_NET_CLIENT_LIST(WINDOW)'`
             ).toString();
 
+        console.log('allwindowids', allWindowIdsOutput);
         const allWindowIds = allWindowIdsOutput.match(/0x[\da-f]+/ig);
 
         const codeWindowIds = [];
@@ -62,6 +65,7 @@ function activate(context) {
 
             // Checking the weather the window has a associated process
             const hasProcessId = cp.execSync(`xprop -id ${windowId} _NET_WM_PID`).toString();
+            console.log('hasprocessid', hasProcessId);
 
             if(!(hasProcessId.search('not found')+1)){
                 // Extract process id from the result
@@ -73,13 +77,27 @@ function activate(context) {
         }
 
         function setAlpha(alpha){
+
+            console.log('setting alpha to', alpha);
             if (alpha < 1) {
                 alpha = 1;
             } else if (alpha > 255) {
                 alpha = 255;
             }
 
+            cp.exec(`swaymsg opacity ${(alpha/255).toFixed(2)}`, function(error,stdout, stderr){
+                if (error) {
+                    console.error(`[SWAY] GlassIt error: ${error}`);
+                    return;
+                }
+
+                console.log(stdout.toString());
+                console.log(`[SWAY] GlassIt: set alpha ${alpha}`);
+                config().update('alpha', alpha, true);
+           })
+
             for(const codeWindowId of codeWindowIds){
+                console.log(`gonna exec on`, codeWindowId);
                cp.exec(`xprop  -id ${codeWindowId} -f _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${alpha} / 255)))`, function(error,stdout, stderr){
                     if (error) {
                         console.error(`GlassIt error: ${error}`);

--- a/extension.js
+++ b/extension.js
@@ -4,6 +4,8 @@ const shell = require('node-powershell');
 
 function activate(context) {
 
+    const config = () => workspace.getConfiguration('glassit');
+
     console.log('ctx', process.platform);
     if (process.platform == 'win32') {
         const path = context.asAbsolutePath('./SetTransparency.cs');
@@ -32,82 +34,81 @@ function activate(context) {
                 window.showErrorMessage(`GlassIt Error: ${err}`);
             });
         }
-    } else if (process.platform == 'linux'){
+    } else if (process.platform == 'linux') {
 
         const cp = require('child_process');
-
-        // Checking the weather xprop has installed
-        try {
-            cp.spawnSync('which xprop').toString();
-        } catch (error){
-            console.error(`GlassIt Error: Please install xprop package to use GlassIt.`);
-            return;
-        }
-
-        // Retrieve the process name for the current VS Code instance (Solution for using forks of VS Code)
-        const process_name = process.title.substring(process.title.lastIndexOf('/') + 1);
-
-        // Retrieving the process ids of VS code
-        const processIds = cp.execSync(`pgrep ${process_name}`).toString().split('\n');
-        processIds.pop();
-
-        // Retrieving all window ids
-        const allWindowIdsOutput = cp.execSync(
-            `xprop -root | grep '_NET_CLIENT_LIST(WINDOW)'`
-            ).toString();
-
-        console.log('allwindowids', allWindowIdsOutput);
-        const allWindowIds = allWindowIdsOutput.match(/0x[\da-f]+/ig);
-
         const codeWindowIds = [];
 
-        for(const windowId of allWindowIds){
+        if (config().get('force_sway') === false) {
+            // Checking the weather xprop has installed
+            try {
+                cp.spawnSync('which xprop').toString();
+            } catch (error) {
+                console.error(`GlassIt Error: Please install xprop package to use GlassIt.`);
+                return;
+            }
 
-            // Checking the weather the window has a associated process
-            const hasProcessId = cp.execSync(`xprop -id ${windowId} _NET_WM_PID`).toString();
-            console.log('hasprocessid', hasProcessId);
+            // Retrieve the process name for the current VS Code instance (Solution for using forks of VS Code)
+            const process_name = process.title.substring(process.title.lastIndexOf('/') + 1);
 
-            if(!(hasProcessId.search('not found')+1)){
-                // Extract process id from the result
-               const winProcessId = hasProcessId.replace(/([a-zA-Z_\(\)\s\=])/g,'');
-               if(processIds.includes(winProcessId)){
-                    codeWindowIds.push(windowId);
-               }
+            // Retrieving the process ids of VS code
+            const processIds = cp.execSync(`pgrep ${process_name}`).toString().split('\n');
+            processIds.pop();
+
+            // Retrieving all window ids
+            const allWindowIdsOutput = cp.execSync(
+                `xprop -root | grep '_NET_CLIENT_LIST(WINDOW)'`
+            ).toString();
+
+            const allWindowIds = allWindowIdsOutput.match(/0x[\da-f]+/ig);
+
+            for (const windowId of allWindowIds) {
+
+                // Checking the weather the window has a associated process
+                const hasProcessId = cp.execSync(`xprop -id ${windowId} _NET_WM_PID`).toString();
+
+                if (!(hasProcessId.search('not found') + 1)) {
+                    // Extract process id from the result
+                    const winProcessId = hasProcessId.replace(/([a-zA-Z_\(\)\s\=])/g, '');
+                    if (processIds.includes(winProcessId)) {
+                        codeWindowIds.push(windowId);
+                    }
+                }
             }
         }
 
-        function setAlpha(alpha){
-
-            console.log('setting alpha to', alpha);
+        function setAlpha(alpha) {
             if (alpha < 1) {
                 alpha = 1;
             } else if (alpha > 255) {
                 alpha = 255;
             }
 
-            cp.exec(`swaymsg opacity ${(alpha/255).toFixed(2)}`, function(error,stdout, stderr){
-                if (error) {
-                    console.error(`[SWAY] GlassIt error: ${error}`);
-                    return;
-                }
-
-                console.log(stdout.toString());
-                console.log(`[SWAY] GlassIt: set alpha ${alpha}`);
-                config().update('alpha', alpha, true);
-           })
-
-            for(const codeWindowId of codeWindowIds){
-                console.log(`gonna exec on`, codeWindowId);
-               cp.exec(`xprop  -id ${codeWindowId} -f _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${alpha} / 255)))`, function(error,stdout, stderr){
+            if (config().get('force_sway') === true){
+                console.log(`In force_sway mode...`);
+                cp.exec(`swaymsg opacity ${(alpha / 255).toFixed(2)}`, function (error, stdout, stderr) {
                     if (error) {
                         console.error(`GlassIt error: ${error}`);
                         return;
                     }
-
+    
                     console.log(stdout.toString());
                     console.log(`GlassIt: set alpha ${alpha}`);
                     config().update('alpha', alpha, true);
-               });
+                })
+            } else {
+                for (const codeWindowId of codeWindowIds) {
+                    cp.exec(`xprop  -id ${codeWindowId} -f _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${alpha} / 255)))`, function (error, stdout, stderr) {
+                        if (error) {
+                            console.error(`GlassIt error: ${error}`);
+                            return;
+                        }
+    
+                        console.log(stdout.toString());
+                        console.log(`GlassIt: set alpha ${alpha}`);
+                        config().update('alpha', alpha, true);
+                    });
+                }
             }
         }
     } else {
@@ -115,9 +116,6 @@ function activate(context) {
     }
 
     console.log('Congratulations, your extension "GlassIt VSC" is now active!');
-
-    const config = () => workspace.getConfiguration('glassit');
-
 
     context.subscriptions.push(commands.registerCommand('glassit.increase', () => {
         const alpha = config().get('alpha') - config().get('step');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,108 @@
 {
   "name": "glassit",
   "version": "0.2.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "glassit",
+      "version": "0.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "node-powershell": "^4.0.0"
+      },
+      "devDependencies": {},
+      "engines": {
+        "vscode": "^1.40.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.7.tgz",
+      "integrity": "sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ=="
+    },
+    "node_modules/node-powershell": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/node-powershell/-/node-powershell-4.0.0.tgz",
+      "integrity": "sha512-WCZMLgwkjW9G/DZsZwyCEAXhMMzShLRUlnYS+EETRqRLSdUMbuO4xiQxIOeAutwQgvj75NvC58CorHFlx0olIA==",
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "shortid": "^2.2.14"
+      }
+    },
+    "node_modules/shortid": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+      "dependencies": {
+        "nanoid": "^2.1.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
   "dependencies": {
     "ansi-styles": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
           "type": "integer",
           "default": 5,
           "description": "Increment of alpha"
+        },
+        "glassit.force_sway": {
+          "type": "boolean",
+          "default": false,
+          "description": "Force using swaymsg to set transparency"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,23 +19,6 @@
     "type": "git",
     "url": "https://github.com/hikarin522/GlassIt-VSC.git"
   },
-  "badges": [
-    {
-      "url": "https://vsmarketplacebadge.apphb.com/version/s-nlf-fh.glassit.svg",
-      "description": "Latest Version",
-      "href": "https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit"
-    },
-    {
-      "url": "https://vsmarketplacebadge.apphb.com/installs/s-nlf-fh.glassit.svg",
-      "description": "Total Downloads",
-      "href": "https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit"
-    },
-    {
-      "url": "https://vsmarketplacebadge.apphb.com/rating/s-nlf-fh.glassit.svg",
-      "description": "Ratings",
-      "href": "https://marketplace.visualstudio.com/items?itemName=s-nlf-fh.glassit"
-    }
-  ],
   "bugs": {
     "url": "https://github.com/hikarin522/GlassIt-VSC/issues",
     "email": "hikarin522@outlook.jp"


### PR DESCRIPTION
Sway is a DE based on Wayland, so the `xorg` / `xprop` technique doesn't work. 

Instead, we can directly call `swaymsg` with the opacity, between 0 & 1.

I just added a boolean config which sway users can turn on. This will bypass all xorg/xprop checks.

![image](https://user-images.githubusercontent.com/6680615/211787178-3d5b37cb-eacd-4af3-8366-4daa3a354d9a.png)

<details>


<summary> 
Tested on my machine with following specs
</summary>

```
$ neofetch
                   -`                    raghu@arch
                  .o+`                   ----------
                 `ooo/                   OS: Arch Linux x86_64
                `+oooo:                  Host: 20Q0S05E00 ThinkPad X390
               `+oooooo:                 Kernel: 6.1.4-arch1-1
               -+oooooo+:                Uptime: 2 days, 5 hours, 32 mins
             `/:-:++oooo+:               Packages: 1039 (pacman)
            `/++++/+++++++:              Shell: bash 5.1.16
           `/++++++++++++++:             Resolution: 2560x1440
          `/+++ooooooooooooo/`           WM: sway
         ./ooosssso++osssssso+`          Theme: Adwaita [GTK2/3]
        .oossssso-````/ossssss+`         Icons: Adwaita [GTK2/3]
       -osssssso.      :ssssssso.        Terminal: alacritty
      :osssssss/        osssso+++.       Terminal Font: TerminessTTF Nerd Font Mono
     /ossssssss/        +ssssooo/-       CPU: Intel i7-8565U (8) @ 4.600GHz
   `/ossssso+/:-        -:/+osssso+-     GPU: Intel WhiskeyLake-U GT2 [UHD Graphics 620]
  `+sso+:-`                 `.-/+oso:    Memory: 8935MiB / 15686MiB
 `++:.                           `-/+/
 .`                                 `/
```

</details>

**Note: I had to remove all reference to SVG files, otherwise I couldn't compile the extension.**

Edit: Fixes #43 