### PR TITLE
[Linux] fix process title not being correct causing breakage on forks

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -49,7 +49,7 @@ function activate(context) {
             }
 
             // Retrieve the process name for the current VS Code instance (Solution for using forks of VS Code)
-            const process_name = process.title.substring(process.title.lastIndexOf('/') + 1);
+            const process_name = process.execPath.substring(process.execPath.lastIndexOf('/') + 1);
 
             // Retrieving the process ids of VS code
             const processIds = cp.execSync(`pgrep ${process_name}`).toString().split('\n');


### PR DESCRIPTION
The issue is described in this comment: https://github.com/hikarin522/GlassIt-VSC/issues/45#issuecomment-1428000020

The process title is an editable value which can apparently be overwritten by other extensions, if my understanding is correct.

My proposal is to instead use `process.execPath` . I have tested this on my system with both code and codium and it appears to work for both. I don't know much about node so I myself can't promise this is a perfect fix.

