### PR TITLE
fix: support non-ASCII characters in Windows user profile path

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,3 @@
-
 const { workspace, window, commands } = require('vscode');
 const shell = require('node-powershell');
 
@@ -9,13 +8,19 @@ function activate(context) {
     console.log('ctx', process.platform);
     if (process.platform == 'win32') {
         const path = context.asAbsolutePath('./SetTransparency.cs');
+
+        // Pfad als UTF-16LE Base64 encoden damit Sonderzeichen (ä, ö, ü, ...)
+        // sicher an PowerShell übergeben werden können
+        const pathBase64 = Buffer.from(path, 'utf16le').toString('base64');
+
         const ps = new shell({
             executionPolicy: 'RemoteSigned',
             noProfile: true,
         });
         context.subscriptions.push(ps);
         ps.addCommand('[Console]::OutputEncoding = [Text.Encoding]::UTF8');
-        ps.addCommand(`Add-Type -Path '${path}'`);
+        ps.addCommand(`$csPath = [System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String('${pathBase64}'))`);
+        ps.addCommand(`Add-Type -LiteralPath $csPath`);
 
         function setAlpha(alpha) {
             if (alpha < 1) {
@@ -34,13 +39,13 @@ function activate(context) {
                 window.showErrorMessage(`GlassIt Error: ${err}`);
             });
         }
+
     } else if (process.platform == 'linux') {
 
         const cp = require('child_process');
         const codeWindowIds = [];
 
         if (config().get('force_sway') === false) {
-            // Checking the weather xprop has installed
             try {
                 cp.spawnSync('which xprop').toString();
             } catch (error) {
@@ -48,14 +53,10 @@ function activate(context) {
                 return;
             }
 
-            // Retrieve the process name for the current VS Code instance (Solution for using forks of VS Code)
             const process_name = process.execPath.substring(process.execPath.lastIndexOf('/') + 1);
-
-            // Retrieving the process ids of VS code
             const processIds = cp.execSync(`pgrep ${process_name}`).toString().split('\n');
             processIds.pop();
 
-            // Retrieving all window ids
             const allWindowIdsOutput = cp.execSync(
                 `xprop -root | grep '_NET_CLIENT_LIST(WINDOW)'`
             ).toString();
@@ -63,12 +64,9 @@ function activate(context) {
             const allWindowIds = allWindowIdsOutput.match(/0x[\da-f]+/ig);
 
             for (const windowId of allWindowIds) {
-
-                // Checking the weather the window has a associated process
                 const hasProcessId = cp.execSync(`xprop -id ${windowId} _NET_WM_PID`).toString();
 
                 if (!(hasProcessId.search('not found') + 1)) {
-                    // Extract process id from the result
                     const winProcessId = hasProcessId.replace(/([a-zA-Z_\(\)\s\=])/g, '');
                     if (processIds.includes(winProcessId)) {
                         codeWindowIds.push(windowId);
@@ -84,26 +82,24 @@ function activate(context) {
                 alpha = 255;
             }
 
-            if (config().get('force_sway') === true){
+            if (config().get('force_sway') === true) {
                 console.log(`In force_sway mode...`);
                 cp.exec(`swaymsg opacity ${(alpha / 255).toFixed(2)}`, function (error, stdout, stderr) {
                     if (error) {
                         console.error(`GlassIt error: ${error}`);
                         return;
                     }
-    
                     console.log(stdout.toString());
                     console.log(`GlassIt: set alpha ${alpha}`);
                     config().update('alpha', alpha, true);
-                })
+                });
             } else {
                 for (const codeWindowId of codeWindowIds) {
-                    cp.exec(`xprop  -id ${codeWindowId} -f _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${alpha} / 255)))`, function (error, stdout, stderr) {
+                    cp.exec(`xprop -id ${codeWindowId} -f _NET_WM_WINDOW_OPACITY 32c -set _NET_WM_WINDOW_OPACITY $(printf 0x%x $((0xffffffff * ${alpha} / 255)))`, function (error, stdout, stderr) {
                         if (error) {
                             console.error(`GlassIt error: ${error}`);
                             return;
                         }
-    
                         console.log(stdout.toString());
                         console.log(`GlassIt: set alpha ${alpha}`);
                         config().update('alpha', alpha, true);
@@ -111,6 +107,7 @@ function activate(context) {
                 }
             }
         }
+
     } else {
         return;
     }


### PR DESCRIPTION
Fixes #83

The extension failed when the Windows username contained non-ASCII 
characters (e.g. ä). node-powershell passes commands as plain text, 
which corrupts the path encoding before PowerShell receives it.

Fix: encode the .cs file path as UTF-16LE Base64 in Node.js, then 
decode it in PowerShell via [System.Text.Encoding]::Unicode. 
Base64 is pure ASCII and survives the handoff intact.

Tested on Windows 11 with user profile: C:\Users\Produktivität