### PR TITLE
Blur effect strengthened

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![VSMI]][VSM]
 [![VSMR]][VSM]
 
-VS Code Extension to set window to transparent on Windows and Linux platforms.
+VS Code Extension to set window to transparent on Windows and Linux platforms, with a more pronounced blurred background effect on Windows.
 
 This extension is the VS Code version of [GlassIt] of Sublime Text plugin.
 

--- a/SetTransparency.cs
+++ b/SetTransparency.cs
@@ -34,7 +34,14 @@ namespace GlassIt
 
                     WS windowLong = User32.GetWindowLong(hWnd, GWL.EXSTYLE);
                     User32.SetWindowLong(hWnd, GWL.EXSTYLE, windowLong | WS.EX_LAYERED);
-                    return User32.SetLayeredWindowAttributes(hWnd, 0, alpha, LWA.ALPHA);
+
+                    if (!User32.SetLayeredWindowAttributes(hWnd, 0, alpha, LWA.ALPHA))
+                    {
+                        return false;
+                    }
+
+                    User32.EnableBlurBehindWindow(hWnd);
+                    return true;
                 }, IntPtr.Zero);
 
                 if (!result)
@@ -71,6 +78,40 @@ namespace Windows
 
         [DllImport("user32.dll")]
         public static extern bool SetLayeredWindowAttributes(IntPtr hWnd, uint crKey, byte bAlpha, LWA dwFlags);
+
+        [DllImport("user32.dll")]
+        public static extern int SetWindowCompositionAttribute(IntPtr hWnd, ref WindowCompositionAttribData data);
+
+        public static void EnableBlurBehindWindow(IntPtr hWnd)
+        {
+            var accent = new AccentPolicy
+            {
+                AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND,
+                AccentFlags = 0x20,
+                GradientColor = 0x00000000,
+                AnimationId = 0
+            };
+
+            var data = new WindowCompositionAttribData
+            {
+                Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY,
+                SizeOfData = Marshal.SizeOf(accent),
+                Data = Marshal.AllocHGlobal(Marshal.SizeOf(accent))
+            };
+
+            try
+            {
+                Marshal.StructureToPtr(accent, data.Data, false);
+                SetWindowCompositionAttribute(hWnd, ref data);
+            }
+            finally
+            {
+                if (data.Data != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(data.Data);
+                }
+            }
+        }
     }
 
     internal enum GWL: int
@@ -94,5 +135,36 @@ namespace Windows
     {
         COLORKEY = 1,
         ALPHA = 2,
+    }
+
+    internal enum AccentState
+    {
+        ACCENT_DISABLED = 0,
+        ACCENT_ENABLE_GRADIENT = 1,
+        ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
+        ACCENT_ENABLE_BLURBEHIND = 3,
+        ACCENT_INVALID_STATE = 4
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct AccentPolicy
+    {
+        public AccentState AccentState;
+        public int AccentFlags;
+        public int GradientColor;
+        public int AnimationId;
+    }
+
+    internal enum WindowCompositionAttribute
+    {
+        WCA_ACCENT_POLICY = 19
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct WindowCompositionAttribData
+    {
+        public WindowCompositionAttribute Attribute;
+        public IntPtr Data;
+        public int SizeOfData;
     }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "email": "hikarin522@outlook.jp"
   },
   "activationEvents": [
-    "*"
+    "onCommand:glassit.increase",
+    "onCommand:glassit.decrease",
+    "onCommand:glassit.maximize",
+    "onCommand:glassit.minimize"
   ],
   "main": "./extension",
   "contributes": {
@@ -50,8 +53,8 @@
       "properties": {
         "glassit.alpha": {
           "type": "integer",
-          "default": 220,
-          "description": "Transparency level [1-255]"
+          "default": 180,
+          "description": "Transparency level [1-255]. Lower values make the blur effect more noticeable."
         },
         "glassit.step": {
           "type": "integer",


### PR DESCRIPTION
The Windows path now uses a blur-behind window composition effect, and the default transparency has been lowered so the background blur is more visible right away.